### PR TITLE
Fixed Eclipse issue with missing Maven property

### DIFF
--- a/rice-middleware/sampleapp/pom.xml
+++ b/rice-middleware/sampleapp/pom.xml
@@ -39,6 +39,7 @@
     <kuali.generate.reports>false</kuali.generate.reports>
     <saucelabs.connect.includes>**/*Aft.java</saucelabs.connect.includes>
     <stests.includes>**/*Aft.java</stests.includes>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
   </properties>
 
   <build>

--- a/rice-middleware/standalone/pom.xml
+++ b/rice-middleware/standalone/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <web.launch.context.path>/standalone</web.launch.context.path>
     <bootstrap.spring.file>classpath:org/kuali/rice/standalone/config/StandaloneSpringBeans.xml</bootstrap.spring.file>
+    <failOnMissingWebXml>true</failOnMissingWebXml>
   </properties>
 
   <build>


### PR DESCRIPTION
Eclipse expects every project which does not have an explicit web.xml
file to set the failOnMissingWebXml property to false.  The file comes
in through an overlay but Eclipse doesn't understand that so this
property is only necessary for Eclipse.
