### PR TITLE
Fixed missing dependency on servlet-api

### DIFF
--- a/rice-middleware/core-service/impl/pom.xml
+++ b/rice-middleware/core-service/impl/pom.xml
@@ -146,6 +146,12 @@
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
     </dependency>
+    
+    <!-- provided-scoped dependencies -->
+    <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+    </dependency>
 
     <!-- test-scoped dependencies: -->
 


### PR DESCRIPTION
Java 8 is more strict about needing dependencies for different modules
so the core-impl module needed an explicit dependency on the servlet
API.
