### PR TITLE
Fix integration tests

### DIFF
--- a/rice-framework/krad-data/src/main/java/org/kuali/rice/krad/data/provider/impl/CompositeMetadataProviderImpl.java
+++ b/rice-framework/krad-data/src/main/java/org/kuali/rice/krad/data/provider/impl/CompositeMetadataProviderImpl.java
@@ -16,6 +16,7 @@
 package org.kuali.rice.krad.data.provider.impl;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +72,7 @@ public class CompositeMetadataProviderImpl extends MetadataProviderBase implemen
 				// from the keys of the map
 				Map<Class<?>, DataObjectMetadata> metadata = null;
 				if (provider.requiresListOfExistingTypes()) {
-					metadata = provider.provideMetadataForTypes(masterMetadataMap.keySet());
+					metadata = provider.provideMetadataForTypes(Collections.list(masterMetadataMap.keys()));
 				} else {
 					metadata = provider.provideMetadata();
 				}

--- a/rice-framework/krad-sampleapp/impl/src/main/java/edu/sampleu/travel/dataobject/TravelerDetail.java
+++ b/rice-framework/krad-sampleapp/impl/src/main/java/edu/sampleu/travel/dataobject/TravelerDetail.java
@@ -15,10 +15,22 @@
  */
 package edu.sampleu.travel.dataobject;
 
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.Transient;
+
 import org.apache.commons.lang.StringUtils;
 import org.kuali.rice.core.api.mo.common.active.MutableInactivatable;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.krad.bo.DataObjectBase;
+import org.kuali.rice.krad.data.jpa.PortableSequenceGenerator;
 import org.kuali.rice.krad.data.provider.annotation.InheritProperties;
 import org.kuali.rice.krad.data.provider.annotation.InheritProperty;
 import org.kuali.rice.krad.data.provider.annotation.Label;
@@ -26,27 +38,17 @@ import org.kuali.rice.krad.data.provider.annotation.Relationship;
 import org.kuali.rice.krad.data.provider.annotation.UifAutoCreateViewType;
 import org.kuali.rice.krad.data.provider.annotation.UifAutoCreateViews;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-import javax.persistence.Transient;
-import java.util.Date;
-
 
 @Entity
 @Table(name="TRVL_TRAVELER_DTL_T")
 @UifAutoCreateViews({UifAutoCreateViewType.INQUIRY, UifAutoCreateViewType.LOOKUP})
 public class TravelerDetail extends DataObjectBase implements MutableInactivatable {
-	private static final long serialVersionUID = -7169083136626617130L;
 
+	private static final long serialVersionUID = -7169083136626617130L;
+	
     @Id
     @GeneratedValue(generator = "TRVL_TRAVELER_DTL_ID_S")
-    @SequenceGenerator(name = "TRVL_TRAVELER_DTL_ID_S", sequenceName = "TRVL_TRAVELER_DTL_ID_S", allocationSize = 5)
+    @PortableSequenceGenerator(name = "TRVL_TRAVELER_DTL_ID_S")
     @Column(name = "id", length = 40, nullable = false)
 	protected String id;
     @Column(name = "doc_nbr", length=14)

--- a/rice-middleware/it/kim/src/test/groovy/org/kuali/rice/kim/impl/EntityPersistenceTest.groovy
+++ b/rice-middleware/it/kim/src/test/groovy/org/kuali/rice/kim/impl/EntityPersistenceTest.groovy
@@ -31,7 +31,7 @@ class EntityPersistenceTest extends BoPersistenceTest {
     @Test
     void test_save_entity() {
         EntityBo entity = Factory.make(EntityBo)
-        boService.save(entity, PersistenceOption.FLUSH)
+        entity = boService.save(entity, PersistenceOption.FLUSH)
 
         // assert entity row
         assertRow(standard_fields(entity) + [ ENTITY_ID: entity.id ], "KRIM_ENTITY_T", "ENTITY_ID")

--- a/rice-middleware/it/kim/src/test/groovy/org/kuali/rice/kim/test/EntityFactory.groovy
+++ b/rice-middleware/it/kim/src/test/groovy/org/kuali/rice/kim/test/EntityFactory.groovy
@@ -15,6 +15,10 @@
  */
 package org.kuali.rice.kim.test
 
+import java.sql.Timestamp
+
+import org.joda.time.DateTime
+import org.joda.time.LocalDate;
 import org.kuali.rice.kim.api.KimConstants
 import org.kuali.rice.kim.impl.identity.address.EntityAddressBo
 import org.kuali.rice.kim.impl.identity.address.EntityAddressTypeBo
@@ -41,10 +45,6 @@ import org.kuali.rice.kim.impl.identity.privacy.EntityPrivacyPreferencesBo
 import org.kuali.rice.kim.impl.identity.residency.EntityResidencyBo
 import org.kuali.rice.kim.impl.identity.type.EntityTypeContactInfoBo
 import org.kuali.rice.kim.impl.identity.visa.EntityVisaBo
-import org.kuali.rice.kim.impl.identity.employment.EntityEmploymentTypeBo
-import org.kuali.rice.kim.impl.identity.employment.EntityEmploymentStatusBo
-import org.joda.time.DateTime
-import java.sql.Timestamp
 
 /**
  * Factory for constructing Entity- objects
@@ -56,12 +56,11 @@ class EntityFactory extends Factory {
     }
 
     def EntityBioDemographicsBo(Map fields) {
-        def now = new java.sql.Date(new Date().time)
         def values = [
-            birthDateValue: new java.sql.Date(genDbTimestamp().time),
+            birthDateValue: genDbDate(),
             genderCode: "M",
             genderChangeCode: "...",
-            deceasedDateValue: new java.sql.Date((long) (genDbTimestamp().time + (1000L * 60 * 60 * 24 * 365 * 80))),
+			deceasedDateValue: genDbDate(365 * 80),
             maritalStatusCode: "S",
             primaryLanguageCode: "EN",
             secondaryLanguageCode: "FR",
@@ -190,10 +189,14 @@ class EntityFactory extends Factory {
         new EntityBo(fields)
     }
 
-    protected def genDbTimestamp() {
+    protected Timestamp genDbTimestamp(int daysFromNow = 0) {
         // this should not be rocket science but we have to deal
         // but it appears mysql (driver?) is truncating time component of datetimes
         // so we can only portably test timestamps without times...
-        new Timestamp(new Date().clearTime().time)
+        new Timestamp(DateTime.now().plusDays(daysFromNow).withTimeAtStartOfDay().getMillis());
     }
+	
+	protected Date genDbDate(int daysFromNow = 0) {
+		new java.sql.Date(DateTime.now().plusDays(daysFromNow).withTimeAtStartOfDay().getMillis());
+	}
 }


### PR DESCRIPTION
I did a full run of integration tests against mysql on my local machine (surprisingly only took 1.5 hours to run). I ended up with 2 errors and 1 failure. The errors were related to the fact that TravelerDetail was not using a PortableSequenceGenerator (I assume the test was passing just fine on oracle).The failure was a subtle issue with timestamps and datetime fields on the EntityPersistence test. Switched the test harness factory to use JodaTime (of course) and that fixed the problems.
